### PR TITLE
LSP-885: Complete the configuration for search-api

### DIFF
--- a/serverless.env.yml
+++ b/serverless.env.yml
@@ -1,0 +1,13 @@
+default: &DEFAULT
+  OPENSEARCH_HOST: ${ssm:/production/search-api/default/host}
+  OPENSEARCH_MASTER_USERNAME: ${ssm:/production/search-api/default/master-username}
+  OPENSEARCH_MASTER_PASSWORD: ${ssm:/production/search-api/default/master-password}
+  DATABASE_USER: YOUR_DATABASE_USER
+  DATABASE_PASSWORD: YOUR_DATABASE_PASSWORD
+  DATABASE_NAME: YOUR_DATABASE_NAME
+  ELASTICSEARCH_ENDPOINT: YOUR_ES_ENDPOINT
+  OPENSEARCH_PORT: 443
+  AWS_REGION: us-east-1
+
+prod: *DEFAULT
+dev: *DEFAULT

--- a/serverless.yml
+++ b/serverless.yml
@@ -3,16 +3,8 @@ service: search-api-sls
 provider:
   name: aws
   runtime: nodejs18.x
-  environment:
-    DATABASE_HOST: YOUR_DATABASE_HOST
-    DATABASE_USER: YOUR_DATABASE_USER
-    DATABASE_PASSWORD: YOUR_DATABASE_PASSWORD
-    DATABASE_NAME: YOUR_DATABASE_NAME
-    ELASTICSEARCH_ENDPOINT: YOUR_ES_ENDPOINT
-    OPENSEARCH_HOST: YOUR_OPENSEARCH_HOST
-    OPENSEARCH_PORT: YOUR_OPENSEARCH_PORT
-    AWS_REGION: us-east-1
-    STAGE: ${self:custom.stage}
+  environment: ${file(serverless.env.yml):${self:custom.stage}}
+
   
 custom:
   stage: ${opt:stage, 'dev'}

--- a/src/engines/OpenSearch/openSearchClient.js
+++ b/src/engines/OpenSearch/openSearchClient.js
@@ -20,20 +20,23 @@ class OpenSearchClient {
     this.service = config.service || (this.host.includes('aoss') ? 'aoss' : 'es');
     this.protocol = config.protocol || 'https';
     this.timeout = config.timeout || 5000;
+    this.username = config.username;
+    this.password = config. password;
     this.client = this.createClient();
   }
 
   createClient() {
-     const node = `${this.protocol}://${this.host}:${this.port}`;
-    
+    const node = `${this.protocol}://${this.host}:${this.port}`;
     const clientConfig = {
       node: node,
       requestTimeout: this.timeout,
-      ...AwsSigv4Signer({
-        region: this.region,
-        service: this.service,
-        getCredentials: () => defaultProvider()()
-      })
+      auth: {
+        username: this.username,
+        password: this.password
+      },
+      ssl: {
+        rejectUnauthorized: false
+      }
     };
 
     return new Client(clientConfig);
@@ -46,8 +49,7 @@ class OpenSearchClient {
    */
   async indexExists(indexName) {
     try {
-      console.log("indexname =>", indexName);
-      if(!indexName) {
+      if (!indexName) {
         throw new Error('Index name should be present');
       }
       const response = await this.client.indices.exists({
@@ -55,8 +57,7 @@ class OpenSearchClient {
       });
       return response.body;
     } catch (error) {
-      console.error('Error checking index existence:', error);
-      throw error;
+      throw new Error(`OpenSearch operation failed: ${error.message ? error.message: error}`);
     }
   }
 

--- a/src/engines/OpenSearch/openSearchClient.js
+++ b/src/engines/OpenSearch/openSearchClient.js
@@ -21,7 +21,7 @@ class OpenSearchClient {
     this.protocol = config.protocol || 'https';
     this.timeout = config.timeout || 5000;
     this.username = config.username;
-    this.password = config. password;
+    this.password = config.password;
     this.client = this.createClient();
   }
 
@@ -35,7 +35,7 @@ class OpenSearchClient {
         password: this.password
       },
       ssl: {
-        rejectUnauthorized: false
+        rejectUnauthorized:  process.env.NODE_ENV === 'production' ? true : false
       }
     };
 

--- a/src/handlers/osSearchHandler.js
+++ b/src/handlers/osSearchHandler.js
@@ -1,12 +1,8 @@
 const OpenSearchClient = require('../engines/OpenSearch/openSearchClient');
 const { buildQuery } = require('../utils/esHelpers');
+const { getOpenSearchClient } = require('../lib/opensearch-client');
 
-const config = {
-  host: process.env.OPENSEARCH_HOST,
-  port: parseInt(process.env.OPENSEARCH_PORT) || 443,
-  region: process.env.AWS_REGION || 'us-east-1',
-};
-const osClient = new OpenSearchClient(config);
+const osClient = getOpenSearchClient();
 module.exports.index = async (event) => {
   try {
     const { index, query, from, size, langId } = event.queryStringParameters;

--- a/src/lib/opensearch-client.js
+++ b/src/lib/opensearch-client.js
@@ -1,0 +1,24 @@
+const OpenSearchClient = require('../engines/OpenSearch/openSearchClient');
+
+let osClientInstance = null;
+
+const getOpenSearchClient = () => {
+  if (!osClientInstance) {
+    const config = {
+      host: process.env.OPENSEARCH_HOST,
+      port: parseInt(process.env.OPENSEARCH_PORT) || 443,
+      region: process.env.AWS_REGION || 'us-east-1',
+      username: process.env.OPENSEARCH_MASTER_USERNAME,
+      password: process.env.OPENSEARCH_MASTER_PASSWORD
+    };
+    if (!config.host || !config.username || !config.password) {
+      throw new Error('Missing required OpenSearch configuration in environment variables');
+    }
+    console.log('Initializing OpenSearch Client:', config.host);
+    osClientInstance = new OpenSearchClient(config);
+  }
+
+  return osClientInstance;
+};
+
+module.exports = { getOpenSearchClient };

--- a/src/lib/opensearch-client.js
+++ b/src/lib/opensearch-client.js
@@ -14,7 +14,9 @@ const getOpenSearchClient = () => {
     if (!config.host || !config.username || !config.password) {
       throw new Error('Missing required OpenSearch configuration in environment variables');
     }
-    console.log('Initializing OpenSearch Client:', config.host);
+     if (process.env.NODE_ENV !== 'production') {
+      console.log('Initializing OpenSearch Client:', config.host);
+    }
     osClientInstance = new OpenSearchClient(config);
   }
 


### PR DESCRIPTION
## Background
This PR completes the configuration that is required to run the search-sls-api
Ticket - [LSP-885: Complete the configuration for search-api-sls repository](https://devicebits.atlassian.net/browse/LSP-885)

## Changes done
- Created `serverless.env.yml` with necessary configuration
- Updated `serverless.yml` to get values from environment file
- Created a `src/lib/opensearch-client.js` with `getOpenSearchClient` function to import the config 
- Changed the opensearch client initialisation to use `auth` with username and password instead of `AwsSigv4Signer`

## Pending to be done
Update the `dev` in `serverless.env.yml` with staging domain name and credentials

## Notes
None

